### PR TITLE
Move P1 & P2 informations to seperate sensors and reduce code repitition

### DIFF
--- a/custom_components/apsystemsapi_local/sensor.py
+++ b/custom_components/apsystemsapi_local/sensor.py
@@ -102,7 +102,7 @@ async def async_setup_entry(
 class BaseSensor(SensorEntity):
     """Representation of an APsystem sensor."""
 
-    _attr_available = False
+    _attr_available = True
 
     def __init__(
         self, api: APsystemsEZ1M, device_name: str, sensor_name: str, sensor_id: str
@@ -141,7 +141,7 @@ class BaseSensor(SensorEntity):
         try:
             data = await self._api.get_output_data()
             self.update_state(data)
-            self._attr_available = False
+            self._attr_available = True
         except (client_exceptions.ClientConnectionError, asyncio.TimeoutError):
             self._attr_available = False
 

--- a/custom_components/apsystemsapi_local/sensor.py
+++ b/custom_components/apsystemsapi_local/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME, UnitOfEnergy, UnitOf
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import DOMAIN
 

--- a/custom_components/apsystemsapi_local/sensor.py
+++ b/custom_components/apsystemsapi_local/sensor.py
@@ -46,17 +46,53 @@ async def async_setup_entry(
             sensor_name="Total Power",
             sensor_id="total_power",
         ),
+        PowerSensorTotalP1(
+            api,
+            device_name=config[CONF_NAME],
+            sensor_name="Total Power P1",
+            sensor_id="total_power_p1",
+        ),
+        PowerSensorTotalP2(
+            api,
+            device_name=config[CONF_NAME],
+            sensor_name="Total Power P2",
+            sensor_id="total_power_p2",
+        ),
         LifetimeEnergy(
             api,
             device_name=config[CONF_NAME],
             sensor_name="Lifetime Production",
             sensor_id="lifetime_production",
         ),
+        LifetimeEnergyP1(
+            api,
+            device_name=config[CONF_NAME],
+            sensor_name="Lifetime Production P1",
+            sensor_id="lifetime_production_p1",
+        ),
+        LifetimeEnergyP2(
+            api,
+            device_name=config[CONF_NAME],
+            sensor_name="Lifetime Production P2",
+            sensor_id="lifetime_production_p2",
+        ),
         TodayEnergy(
             api,
             device_name=config[CONF_NAME],
             sensor_name="Today Production",
             sensor_id="today_production",
+        ),
+        TodayEnergyP1(
+            api,
+            device_name=config[CONF_NAME],
+            sensor_name="Today Production P1",
+            sensor_id="today_production_p1",
+        ),
+        TodayEnergyP2(
+            api,
+            device_name=config[CONF_NAME],
+            sensor_name="Today Production_p2",
+            sensor_id="today_production_p2",
         ),
     ]
 
@@ -128,8 +164,26 @@ class BasePowerSensor(BaseSensor):
 
 class PowerSensorTotal(BasePowerSensor):
     def update_state(self, data):
-        self._attributes = {"p1": data.p1, "p2": data.p2}
+        self._attributes = None
         self._state = data.p1 + data.p2
+
+    async def async_update(self):
+        await self.async_update_data()
+
+
+class PowerSensorTotalP1(BasePowerSensor):
+    def update_state(self, data):
+        self._attributes = None
+        self._state = data.p1
+
+    async def async_update(self):
+        await self.async_update_data()
+
+
+class PowerSensorTotalP2(BasePowerSensor):
+    def update_state(self, data):
+        self._attributes = None
+        self._state = data.p2
 
     async def async_update(self):
         await self.async_update_data()
@@ -152,12 +206,56 @@ class LifetimeEnergy(BaseEnergySensor):
         await self.async_update_data()
 
 
+class LifetimeEnergyP1(BaseEnergySensor):
+    _attr_state_class = SensorStateClass.TOTAL
+
+    def update_state(self, data):
+        self._attributes = None
+        self._state = data.te1
+
+    async def async_update(self):
+        await self.async_update_data()
+
+
+class LifetimeEnergyP2(BaseEnergySensor):
+    _attr_state_class = SensorStateClass.TOTAL
+
+    def update_state(self, data):
+        self._attributes = None
+        self._state = data.te2
+
+    async def async_update(self):
+        await self.async_update_data()
+
+
 class TodayEnergy(BaseEnergySensor):
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
 
     def update_state(self, data):
-        self._attributes = {"p1": data.e1, "p2": data.e2}
+        self._attributes = None
         self._state = data.e1 + data.e2
+
+    async def async_update(self):
+        await self.async_update_data()
+
+
+class TodayEnergyP1(BaseEnergySensor):
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def update_state(self, data):
+        self._attributes = None
+        self._state = data.e1
+
+    async def async_update(self):
+        await self.async_update_data()
+
+
+class TodayEnergyP2(BaseEnergySensor):
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def update_state(self, data):
+        self._attributes = None
+        self._state = data.e2
 
     async def async_update(self):
         await self.async_update_data()

--- a/custom_components/apsystemsapi_local/sensor.py
+++ b/custom_components/apsystemsapi_local/sensor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Optional
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -34,7 +33,7 @@ async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: config_entries.ConfigEntry,
     add_entities: AddEntitiesCallback,
-    discovery_info: Optional[DiscoveryInfoType] = None,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the sensor platform."""
     config = hass.data[DOMAIN][config_entry.entry_id]
@@ -127,7 +126,7 @@ class BaseSensor(SensorEntity):
         return self._state
 
     @property
-    def unique_id(self) -> Optional[str]:
+    def unique_id(self) -> str | None:
         return f"apsystemsapi_{self._device_name}_{self._sensor_id}"
 
     @property

--- a/custom_components/apsystemsapi_local/sensor.py
+++ b/custom_components/apsystemsapi_local/sensor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Optional
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -33,7 +34,7 @@ async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: config_entries.ConfigEntry,
     add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
+    discovery_info: Optional[DiscoveryInfoType] = None,
 ) -> None:
     """Set up the sensor platform."""
     config = hass.data[DOMAIN][config_entry.entry_id]
@@ -126,7 +127,7 @@ class BaseSensor(SensorEntity):
         return self._state
 
     @property
-    def unique_id(self) -> str | None:
+    def unique_id(self) -> Optional[str]:
         return f"apsystemsapi_{self._device_name}_{self._sensor_id}"
 
     @property

--- a/custom_components/apsystemsapi_local/sensor.py
+++ b/custom_components/apsystemsapi_local/sensor.py
@@ -102,8 +102,7 @@ async def async_setup_entry(
 class BaseSensor(SensorEntity):
     """Representation of an APsystem sensor."""
 
-    _attr_available = True
-    _attributes = {}
+    _attr_available = False
 
     def __init__(
         self, api: APsystemsEZ1M, device_name: str, sensor_name: str, sensor_id: str
@@ -138,16 +137,11 @@ class BaseSensor(SensorEntity):
             model="EZ1-M",
         )
 
-    @property
-    def extra_state_attributes(self):
-        """Return entity specific state attributes."""
-        return self._attributes
-
     async def async_update_data(self):
         try:
             data = await self._api.get_output_data()
             self.update_state(data)
-            self._attr_available = True
+            self._attr_available = False
         except (client_exceptions.ClientConnectionError, asyncio.TimeoutError):
             self._attr_available = False
 
@@ -164,7 +158,6 @@ class BasePowerSensor(BaseSensor):
 
 class PowerSensorTotal(BasePowerSensor):
     def update_state(self, data):
-        self._attributes = None
         self._state = data.p1 + data.p2
 
     async def async_update(self):
@@ -173,7 +166,6 @@ class PowerSensorTotal(BasePowerSensor):
 
 class PowerSensorTotalP1(BasePowerSensor):
     def update_state(self, data):
-        self._attributes = None
         self._state = data.p1
 
     async def async_update(self):
@@ -182,7 +174,6 @@ class PowerSensorTotalP1(BasePowerSensor):
 
 class PowerSensorTotalP2(BasePowerSensor):
     def update_state(self, data):
-        self._attributes = None
         self._state = data.p2
 
     async def async_update(self):
@@ -199,7 +190,6 @@ class LifetimeEnergy(BaseEnergySensor):
     _attr_state_class = SensorStateClass.TOTAL
 
     def update_state(self, data):
-        self._attributes = {"p1": data.te1, "p2": data.te2}
         self._state = data.te1 + data.te2
 
     async def async_update(self):
@@ -210,7 +200,6 @@ class LifetimeEnergyP1(BaseEnergySensor):
     _attr_state_class = SensorStateClass.TOTAL
 
     def update_state(self, data):
-        self._attributes = None
         self._state = data.te1
 
     async def async_update(self):
@@ -221,7 +210,6 @@ class LifetimeEnergyP2(BaseEnergySensor):
     _attr_state_class = SensorStateClass.TOTAL
 
     def update_state(self, data):
-        self._attributes = None
         self._state = data.te2
 
     async def async_update(self):
@@ -232,7 +220,6 @@ class TodayEnergy(BaseEnergySensor):
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
 
     def update_state(self, data):
-        self._attributes = None
         self._state = data.e1 + data.e2
 
     async def async_update(self):
@@ -243,7 +230,6 @@ class TodayEnergyP1(BaseEnergySensor):
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
 
     def update_state(self, data):
-        self._attributes = None
         self._state = data.e1
 
     async def async_update(self):
@@ -254,7 +240,6 @@ class TodayEnergyP2(BaseEnergySensor):
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
 
     def update_state(self, data):
-        self._attributes = None
         self._state = data.e2
 
     async def async_update(self):


### PR DESCRIPTION
Hello, with reference to my issue https://github.com/SonnenladenGmbH/APsystems-EZ1-API-HomeAssistant/issues/2, in this PR, independent sensors are created from the information of P1 & P2 and these are removed from the attributes.

I have also simplified the code a little because it contained repetitive patterns, especially in the `async_update` methods of the sensor classes. So I created a common method for updating sensor data in the BaseSensor class to reduce repetition and utilized inheritance to set class attributes in `BasePowerSensor` and `BaseEnergySensor` instead of repeating them in each subclass.

I think the code can be further simplified by restructuring and using `SensorEntityDescription` instead of defining each sensor in it's own subclass. But I have to think more about that first