### PR TITLE
change BasePowerSensor device_class to ENERGY

### DIFF
--- a/custom_components/apsystemsapi_local/sensor.py
+++ b/custom_components/apsystemsapi_local/sensor.py
@@ -145,9 +145,9 @@ class BaseSensor(CoordinatorEntity, SensorEntity):
 
 
 class BasePowerSensor(BaseSensor):
-    _device_class = SensorDeviceClass.POWER
+    _device_class = SensorDeviceClass.ENERGY
     _attr_native_unit_of_measurement = UnitOfPower.WATT
-    _attr_device_class = SensorDeviceClass.POWER
+    _attr_device_class = SensorDeviceClass.ENERGY
     _attr_state_class = SensorStateClass.MEASUREMENT
 
 


### PR DESCRIPTION
This PR resolves #44.

If there is a reason to keep the device class at `power` I'd like to hear about it and work out a solution that fits all the needs.

Cheers,
JM-Lemmi